### PR TITLE
Fix minor issues in finetune script

### DIFF
--- a/scripts/finetune_dataset.py
+++ b/scripts/finetune_dataset.py
@@ -76,9 +76,9 @@ for rerun_iter in range(5):
         nb_model_classes = 2 if use_f1_score else nb_classes
         model = torchmoji_transfer(
                     nb_model_classes,
-                    data['maxlen'], weight_path,
+                    weight_path,
                     extend_embedding=data['added'])
-        model.summary()
+        print(model)
 
         # Training
         print('Training: {}'.format(path))


### PR DESCRIPTION
The finetune script appears to have two issues: 1. it calls `model.summary()` which exists only in Keras. A pytorch equivalent would be to just replace with `print(model)`. And the torchmoji_transfer function arguments are not correct.