### PR TITLE
Compatibility with PyTorch 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 TorchMoji is a [pyTorch](http://pytorch.org/) implementation of the [DeepMoji](https://github.com/bfelbo/DeepMoji) model developped by Bjarke Felbo, Alan Mislove, Anders Søgaard, Iyad Rahwan and Sune Lehmann.
 
 This model trained on 1.2 billion tweets with emojis to understand how language is used to express emotions. Through transfer learning the model can obtain state-of-the-art performance on many emotion-related text modeling tasks.
-  
+
 Try the online demo of DeepMoji [http://deepmoji.mit.edu](http://deepmoji.mit.edu/)! See the [paper](https://arxiv.org/abs/1708.00524), [blog post](https://medium.com/@bjarkefelbo/what-can-we-learn-from-emojis-6beb165a5ea0) or [FAQ](https://www.media.mit.edu/projects/deepmoji/overview/) for more details.
 
 ## Overview
@@ -15,7 +15,7 @@ Try the online demo of DeepMoji [http://deepmoji.mit.edu](http://deepmoji.mit.ed
 * [model/](model) contains the pretrained model and vocabulary.
 * [data/](data) contains raw and processed datasets that we include in this repository for testing.
 * [tests/](tests) contains unit tests for the codebase.
-  
+
 To start out with, have a look inside the [examples/](examples) directory. See [score_texts_emojis.py](examples/score_texts_emojis.py) for how to use DeepMoji to extract emoji predictions, [encode_texts.py](examples/encode_texts.py) for how to convert text into 2304-dimensional emotional feature vectors or [finetune_youtube_last.py](examples/finetune_youtube_last.py) for how to use the model for transfer learning on a new dataset.
 
 Please consider citing the [paper](https://arxiv.org/abs/1708.00524) of DeepMoji if you use the model or code (see below for citation).
@@ -26,12 +26,12 @@ We assume that you're using [Python 2.7-3.5](https://www.python.org/downloads/) 
 
 First you need to install [pyTorch (version 0.2+)](http://pytorch.org/), currently by:
 ```bash
-conda install pytorch -c soumith
+conda install pytorch -c pytorch
 ```
 At the present stage the model can't make efficient use of CUDA. See details in the [Hugging Face blog post](https://medium.com/huggingface/understanding-emotions-from-keras-to-pytorch-3ccb61d5a983).
 
 When pyTorch is installed, run the following in the root directory to install the remaining dependencies:
-  
+
 ```bash
 pip install -e .
 ```
@@ -54,21 +54,21 @@ cd tests
 nosetests -v
 ```
 
-By default, this will also run finetuning tests. These tests train the model for one epoch and then check the resulting accuracy, which may take several minutes to finish. If you'd prefer to exclude those, run the following instead: 
+By default, this will also run finetuning tests. These tests train the model for one epoch and then check the resulting accuracy, which may take several minutes to finish. If you'd prefer to exclude those, run the following instead:
 
 ```bash
 cd tests
 nosetests -v -a '!slow'
 ```
 
-## Disclaimer 
+## Disclaimer
 This code has been tested to work with Python 2.7 and 3.5 on Ubuntu 16.04 and macOS Sierra machines. It has not been optimized for efficiency, but should be fast enough for most purposes. We do not give any guarantees that there are no bugs - use the code on your own responsibility!
 
 ## Contributions
 We welcome pull requests if you feel like something could be improved. You can also greatly help us by telling us how you felt when writing your most recent tweets. Just click [here](http://deepmoji.mit.edu/contribute/) to contribute.
 
 ## License
-This code and the pretrained model is licensed under the MIT license. 
+This code and the pretrained model is licensed under the MIT license.
 
 ## Benchmark datasets
 The benchmark datasets are uploaded to this repository for convenience purposes only. They were not released by us and we do not claim any rights on them. Use the datasets at your responsibility and make sure you fulfill the licenses that they were released with. If you use any of the benchmark datasets please consider citing the original authors.

--- a/torchmoji/model_def.py
+++ b/torchmoji/model_def.py
@@ -215,7 +215,7 @@ class TorchMoji(nn.Module):
         x = self.embed_dropout(x)
 
         # Update packed sequence data for RNN
-        packed_input = PackedSequence(data=x, batch_sizes=packed_input.batch_sizes)
+        packed_input = PackedSequence(x, packed_input.batch_sizes)
 
         # skip-connection from embedding to output eases gradient-flow and allows access to lower-level features
         # ordering of the way the merge is done is important for consistency with the pretrained model
@@ -223,10 +223,10 @@ class TorchMoji(nn.Module):
         lstm_1_output, _ = self.lstm_1(lstm_0_output, hidden)
 
         # Update packed sequence data for attention layer
-        packed_input = PackedSequence(data=torch.cat((lstm_1_output.data,
-                                                      lstm_0_output.data,
-                                                      packed_input.data), dim=1),
-                                      batch_sizes=packed_input.batch_sizes)
+        packed_input = PackedSequence(torch.cat((lstm_1_output.data,
+                                                 lstm_0_output.data,
+                                                 packed_input.data), dim=1),
+                                      packed_input.batch_sizes)
 
         input_seqs, _ = pad_packed_sequence(packed_input, batch_first=True)
 


### PR DESCRIPTION
On newest PyTorch `PackedSequence` takes in `*args` so the current constructor calls don't work anymore (although it shouldn't really be constructed from user land). This patch fixes that.

Also see the relevant https://github.com/pytorch/pytorch/pull/9864 that adds support for this on master. However, that patch isn't making into the new release we (the PyTorch team) are preparing so this change will be needed for the upcoming released PyTorch.